### PR TITLE
Fix setting key in checkType()

### DIFF
--- a/curve25519.go
+++ b/curve25519.go
@@ -81,10 +81,10 @@ func (c ecdh25519) ComputeSecret(private crypto.PrivateKey, peersPublic crypto.P
 func checkType(key *[32]byte, typeToCheck interface{}) (ok bool) {
 	switch t := typeToCheck.(type) {
 	case [32]byte:
-		key = &t
+		*key = t
 		ok = true
 	case *[32]byte:
-		key = t
+		*key = *t
 		ok = true
 	case []byte:
 		if len(t) == 32 {


### PR DESCRIPTION
For data passed by reference, Go passes the pointer itself
by copy. Due to this, the current code overwrote the function's
local copy of the pointer, without actually setting the
underlying data structure.

After function return, the caller's pointer still points to
the empty data.

This caused ComputeSecret() to work on uninitialized keys,
generating the same shared secret for every turn:

```
A Private: MBwLCzRztt+bDeAyA8DgP9RRnhw8YQI7FDYqtcpvTG0=
A Public : nF6kuh35ywhNeLxuhreRmLLXqbGiFCZrDHqdSbhld00=
B Private: qLxaf0Ya6HJjADF9OAIk5mdJc8dIxEuW0UBplzJVqXI=
B Public : PanYjWkSRp+EOS2DyaT83IdRltwbDj+CYqaLyjBSCgM=
Secret   : AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
```

While unverified, there is no reason to suspect that this did
not also break the public key generation from a given private
key, returning an invalid key generated off an uninitialized
private key.