### PR TITLE
Fix length of generated key for generic curves

### DIFF
--- a/ecdh_test.go
+++ b/ecdh_test.go
@@ -40,6 +40,10 @@ func ExampleGeneric() {
 	if !bytes.Equal(secretAlice, secretBob) {
 		fmt.Printf("key exchange failed - secret X coordinates not equal\n")
 	}
+
+	if len(secretAlice) != p256.Params().BitSize/8 {
+		fmt.Printf("computed shared secret is not of the correct size\n")
+	}
 	// Output:
 }
 

--- a/generic.go
+++ b/generic.go
@@ -92,7 +92,8 @@ func (g genericCurve) ComputeSecret(private crypto.PrivateKey, peersPublic crypt
 
 	sX, _ := g.curve.ScalarMult(pubKey.X, pubKey.Y, priKey)
 
-	secret = sX.Bytes()
+	secret = make([]byte, (g.Params().BitSize+7)/8)
+	sX.FillBytes(secret)
 	return
 }
 


### PR DESCRIPTION
According to RFC4492 section 5.10 "the premaster
secret is the x-coordinate of the ECDH shared secret
elliptic curve point represented as an octet string.
Note that this octet string (Z in IEEE 1363 terminology),
as output by FE2OSP (Field Element to Octet String
Conversion Primitive), has constant length for any given
field; leading zeros found in this octet string MUST
NOT be truncated."

Therefore, `FillBytes()` and not `Bytes()` must be used
to convert the x-coordinate into `[]byte`.

Notice that this is also done by the standard golang/tls
library when implementing Diffie-Hellman. (https://github.com/golang/go/blob/master/src/crypto/tls/key_schedule.go#L176)